### PR TITLE
generate HTML log

### DIFF
--- a/kcwikit/scripts/kcwi_gen_log.py
+++ b/kcwikit/scripts/kcwi_gen_log.py
@@ -132,6 +132,14 @@ def create_log(outfile, filename=[], RED=False, BLUE=False, display=False):
 
     t.write(outfile, overwrite=True, format='csv')
 
+    df = t.to_pandas()
+    df_html = df.to_html(classes='table table-light table-striped-columns table-hover')
+    styled_html= f'''<html><head><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous"></head><body>{df_html}</body></html>'''
+    with open(outfile + '.html', 'w') as f:
+        f.write(styled_html)
+
+
+
 
 def main():
     arg_parser = parser_init()


### PR DESCRIPTION
This PR extends the scripts/kcwi_gen_log.py to generate a HTML log to enable to user to view it on the browser. 

Screenshot of generated HTML from code:

![image](https://github.com/user-attachments/assets/579ef60c-8896-4311-aaaa-e51793416064)
